### PR TITLE
Use server-side configuration directly from paypal with correct schema

### DIFF
--- a/__sdk__.js
+++ b/__sdk__.js
@@ -8,23 +8,33 @@ module.exports = {
     entry:           './src/index',
     staticNamespace: '__hosted_fields__',
     configQuery:     `
-      clientConfiguration {
-        assetsUrl
-  			paypalMerchantConfiguration(merchantId: $clientID, locale: $country) {
-     			creditCard {
-        		isPayPalBranded
-						supportedCardBrands
-     			}
-					bank {
-						isPayPalBranded
-					}
-					paypalWallet {
-						isPayPalBranded
-					}
-					paypalCredit {
-						isPayPalBranded
-					}
-   			}
+      fundingEligibility {
+        card {
+          branded
+          vendors {
+            visa {
+              eligible
+            }
+            mastercard {
+              eligible
+            }
+            amex {
+              eligible
+            }
+            discover {
+              eligible
+            }
+            hiper {
+              eligible
+            }
+            elo {
+              eligible
+            }
+            jcb {
+              eligible
+            }
+          }
+        }
       }
     `,
     globals

--- a/vendor/braintree-web/client/globals.js
+++ b/vendor/braintree-web/client/globals.js
@@ -1,0 +1,3 @@
+/* @flow */
+
+module.exports.FUNDING_ELIGIBILITY = __hosted_fields__.serverConfig.fundingEligibility;

--- a/vendor/braintree-web/client/index.js
+++ b/vendor/braintree-web/client/index.js
@@ -2,6 +2,7 @@
 
 var BraintreeError = require('../lib/braintree-error');
 var Client = require('./client');
+var globals = require('./globals');
 var getConfiguration = require('./get-configuration').getConfiguration;
 var VERSION = "3.32.0-payments-sdk-dev";
 var Promise = require('../lib/promise');
@@ -71,6 +72,11 @@ function transformPaymentsSDKConfiguration(config, auth) {
   auth = new Buffer(auth, 'base64');
   auth = JSON.parse(auth.toString('utf8'));
 
+  var supportedCardTypes = Object.keys(globals.FUNDING_ELIGIBILITY.card.vendors)
+    .filter(function(name) {
+      return globals.FUNDING_ELIGIBILITY.card.vendors[name].eligible;
+    });
+
   // TODO which of these fields do we need
   return Promise.resolve({
     analyticsMetadata: 'todo_analytics_metadata_needs_to_be_set',
@@ -88,7 +94,7 @@ function transformPaymentsSDKConfiguration(config, auth) {
         url: 'https://example.com/TODO'
       },
       creditCards: {
-        supportedCardTypes: config.card.supportedCardBrands,
+        supportedCardTypes: supportedCardTypes,
         supportedGateways: [{
           name: 'paypalApi'
         }]


### PR DESCRIPTION
New go-to-live plan is to use funding eligibility config directly from
PayPal / EPM rather than routing through Braintree graphql config service.

This change fixes the referenced config to match the correct key names
which will be inlined by clientsdknodeweb