### PR TITLE
Fix constants in logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "braintree-web": "^3.33.0",
     "paypal-braintree-web-client": "^4.0.0",
+    "paypal-sdk-constants": "^1.0.8",
     "zalgo-promise": "^1.0.34",
     "zoid": "^7.0.6"
   }

--- a/src/component.js
+++ b/src/component.js
@@ -1,6 +1,7 @@
 /* @flow */
 
-import { FPTI_KEY, getLogger, getClientToken, getCorrelationID, getPayPalAPIDomain } from 'paypal-braintree-web-client/src';
+import { getLogger, getClientToken, getCorrelationID, getPayPalAPIDomain } from 'paypal-braintree-web-client/src';
+import { FPTI_KEY } from 'paypal-sdk-constants/src';
 import { ZalgoPromise } from 'zalgo-promise/src';
 
 // toodoo unvendor this when braintree-web is updated


### PR DESCRIPTION
Looks like the location of these constants was moved. (I had been just commenting out the logger calls for a few weeks)