### PR TITLE
Enhancement

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "flow": "flow",
     "build": "rm -rf ./vendor && mkdir -p ./vendor/braintree-web && cp -R ~/bt/braintree.js/dist/npm/* ./vendor/braintree-web",
     "lint": "eslint src/ test/ *.js",
-    "test": "npm run lint && npm run flow-typed && npm run flow && npm run karma",
+    "test": "npm run flow-typed && npm run flow && npm run karma",
     "karma": "cross-env NODE_ENV=test babel-node --plugins=transform-es2015-modules-commonjs ./node_modules/.bin/karma start"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "flow": "flow",
     "build": "rm -rf ./vendor && mkdir -p ./vendor/braintree-web && cp -R ~/bt/braintree.js/dist/npm/* ./vendor/braintree-web",
     "lint": "eslint src/ test/ *.js",
-    "test": "npm run flow-typed && npm run flow && npm run karma",
+    "test": "npm run lint && npm run flow-typed && npm run flow && npm run karma",
     "karma": "cross-env NODE_ENV=test babel-node --plugins=transform-es2015-modules-commonjs ./node_modules/.bin/karma start"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@paypal/card-components",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "description": "Hosted Fields component for unified PayPal/Braintree web sdk",
   "main": "index.js",
   "scripts": {

--- a/src/component.js
+++ b/src/component.js
@@ -19,6 +19,11 @@ const TESTING_CONFIGURATION = {
   }
 };
 
+const LIABILITYSHIFTED_MAPPER = {
+  YES: true,
+  NO: false 
+};
+
 let hosted_payment_session_id = '';
 
 function createSubmitHandler (hostedFieldsInstance, orderIdFunction) : Function {
@@ -74,8 +79,17 @@ function createSubmitHandler (hostedFieldsInstance, orderIdFunction) : Function 
 
         paymentInProgress = false;
 
+        // map liability_shift (YES/NO/UNKNOWN) to liabilityShifted (true/false/undefined) for backward compatibility
+        let liabilityShifted = payload.success;
+
+        if (payload.liability_shift) {
+          liabilityShifted = LIABILITYSHIFTED_MAPPER[payload.liability_shift]
+        }
+
         return {
-          liabilityShifted: payload.success,
+          liabilityShifted,
+          authenticationStatus: payload.status,
+          authenticationReason: payload.authentication_status_reason,
           orderId
         };
       }).catch((err) => {

--- a/src/component.js
+++ b/src/component.js
@@ -21,7 +21,7 @@ const TESTING_CONFIGURATION = {
 
 const LIABILITYSHIFTED_MAPPER = {
   YES: true,
-  NO: false 
+  NO: false
 };
 
 let hosted_payment_session_id = '';
@@ -84,7 +84,7 @@ function createSubmitHandler (hostedFieldsInstance, orderIdFunction) : Function 
 
         // map liability_shift (YES/NO/UNKNOWN) to liabilityShifted (true/false/undefined) for backward compatibility
         if (payload.liability_shift) {
-          liabilityShifted = LIABILITYSHIFTED_MAPPER[payload.liability_shift]
+          liabilityShifted = LIABILITYSHIFTED_MAPPER[payload.liability_shift];
         }
 
         return {

--- a/src/component.js
+++ b/src/component.js
@@ -21,7 +21,7 @@ const TESTING_CONFIGURATION = {
 
 const LIABILITYSHIFTED_MAPPER = {
   YES: true,
-  No:  false
+  NO:  false
 };
 
 let hosted_payment_session_id = '';

--- a/src/component.js
+++ b/src/component.js
@@ -79,9 +79,10 @@ function createSubmitHandler (hostedFieldsInstance, orderIdFunction) : Function 
 
         paymentInProgress = false;
 
-        // map liability_shift (YES/NO/UNKNOWN) to liabilityShifted (true/false/undefined) for backward compatibility
+        // keep this for backward compatible
         let liabilityShifted = payload.success;
 
+        // map liability_shift (YES/NO/UNKNOWN) to liabilityShifted (true/false/undefined) for backward compatibility
         if (payload.liability_shift) {
           liabilityShifted = LIABILITYSHIFTED_MAPPER[payload.liability_shift]
         }

--- a/src/component.js
+++ b/src/component.js
@@ -21,7 +21,7 @@ const TESTING_CONFIGURATION = {
 
 const LIABILITYSHIFTED_MAPPER = {
   YES: true,
-  NO: false
+  No:  false
 };
 
 let hosted_payment_session_id = '';

--- a/test/component.js
+++ b/test/component.js
@@ -442,14 +442,20 @@ describe('hosted-fields-component', () => {
           }
         ]
       };
+      const threeDSResult = {
+        success:                      true,
+        liability_shift:              'YES',
+        status:                       'YES',
+        authentication_status_reason: 'UNAVAILABLE'
+      };
 
       td.when(fakeHostedFieldsInstance.tokenize(td.matchers.isA(Object)))
         .thenReject(error);
 
-      td.when(contingencyFlow.start(expectedUrl)).thenResolve({ success: true });
+      td.when(contingencyFlow.start(expectedUrl)).thenResolve(threeDSResult);
 
       return HostedFields.render(renderOptions, '#button').then((handler) => {
-        return handler.submit().then(() => {
+        return handler.submit().then((actual) => {
           td.verify(contingencyFlowStart(expectedUrl));
         });
       });

--- a/test/component.js
+++ b/test/component.js
@@ -455,7 +455,7 @@ describe('hosted-fields-component', () => {
       td.when(contingencyFlow.start(expectedUrl)).thenResolve(threeDSResult);
 
       return HostedFields.render(renderOptions, '#button').then((handler) => {
-        return handler.submit().then((actual) => {
+        return handler.submit().then(() => {
           td.verify(contingencyFlowStart(expectedUrl));
         });
       });

--- a/test/component.js
+++ b/test/component.js
@@ -443,10 +443,7 @@ describe('hosted-fields-component', () => {
         ]
       };
       const threeDSResult = {
-        success:                      true,
-        liability_shift:              'YES',
-        status:                       'YES',
-        authentication_status_reason: 'UNAVAILABLE'
+        success: true
       };
 
       td.when(fakeHostedFieldsInstance.tokenize(td.matchers.isA(Object)))
@@ -455,8 +452,9 @@ describe('hosted-fields-component', () => {
       td.when(contingencyFlow.start(expectedUrl)).thenResolve(threeDSResult);
 
       return HostedFields.render(renderOptions, '#button').then((handler) => {
-        return handler.submit().then(() => {
+        return handler.submit().then((actual) => {
           td.verify(contingencyFlowStart(expectedUrl));
+          assert.equal(actual.liabilityShifted, true);
         });
       });
     });
@@ -499,6 +497,110 @@ describe('hosted-fields-component', () => {
       return HostedFields.render(renderOptions, '#button').then((handler) => {
         return handler.submit().then(rejectIfResolves).catch(() => {
           td.verify(contingencyFlowStart(expectedUrl));
+        });
+      });
+    });
+
+    it('resolve 3ds contingency and return liabilityShifted true if liability_shifted is YES', () => {
+      const expectedUrl = 'https://www.paypal.com/webapps/helios?action=resolve&flow=3ds&cart_id=21E005655U660730L';
+      const error = {
+        name:    'UNPROCESSABLE_ENTITY',
+        message: 'The requested action could not be performed, semantically incorrect, or failed business validation.',
+        details: [
+          {
+            issue:       'CONTINGENCY',
+            description: 'Buyer needs to resolve following contingency before proceeding with payment'
+          }
+        ],
+        links: [
+          {
+            href:    expectedUrl,
+            rel:    '3ds-contingency-resolution',
+            method: 'GET'
+          },
+          {
+            rel:    'information_link',
+            href:   'https://developer.paypal.com/docs/api/errors/#contingency',
+            method: 'GET'
+          },
+          {
+            rel:    'cancel',
+            href:   'https://api.paypal.com/v1/checkout/orders/21E005655U660730L',
+            method: 'DELETE'
+          }
+        ]
+      };
+      const threeDSResult = {
+        success:                      true,
+        liability_shift:              'YES',
+        status:                       'YES', 
+        authentication_status_reason: 'UNAVAILABLE'
+      };
+
+
+      td.when(fakeHostedFieldsInstance.tokenize(td.matchers.isA(Object)))
+        .thenReject(error);
+
+      td.when(contingencyFlow.start(expectedUrl)).thenResolve(threeDSResult);
+
+      return HostedFields.render(renderOptions, '#button').then((handler) => {
+        return handler.submit().then((actual) => {
+          td.verify(contingencyFlowStart(expectedUrl));
+          assert.equal(actual.liabilityShifted, true);
+          assert.equal(actual.authenticationStatus, threeDSResult.status);
+          assert.equal(actual.authenticationReason, threeDSResult.authentication_status_reason);
+        });
+      });
+    });
+
+    it('resolve 3ds contingency and return liabilityShifted false if liability_shifted is NO', () => {
+      const expectedUrl = 'https://www.paypal.com/webapps/helios?action=resolve&flow=3ds&cart_id=21E005655U660730L';
+      const error = {
+        name:    'UNPROCESSABLE_ENTITY',
+        message: 'The requested action could not be performed, semantically incorrect, or failed business validation.',
+        details: [
+          {
+            issue:       'CONTINGENCY',
+            description: 'Buyer needs to resolve following contingency before proceeding with payment'
+          }
+        ],
+        links: [
+          {
+            href:    expectedUrl,
+            rel:    '3ds-contingency-resolution',
+            method: 'GET'
+          },
+          {
+            rel:    'information_link',
+            href:   'https://developer.paypal.com/docs/api/errors/#contingency',
+            method: 'GET'
+          },
+          {
+            rel:    'cancel',
+            href:   'https://api.paypal.com/v1/checkout/orders/21E005655U660730L',
+            method: 'DELETE'
+          }
+        ]
+      };
+      const threeDSResult = {
+        success:                      true,
+        liability_shift:              'NO',
+        status:                       'YES', 
+        authentication_status_reason: 'UNAVAILABLE'
+      };
+
+
+      td.when(fakeHostedFieldsInstance.tokenize(td.matchers.isA(Object)))
+        .thenReject(error);
+
+      td.when(contingencyFlow.start(expectedUrl)).thenResolve(threeDSResult);
+
+      return HostedFields.render(renderOptions, '#button').then((handler) => {
+        return handler.submit().then((actual) => {
+          td.verify(contingencyFlowStart(expectedUrl));
+          assert.equal(actual.liabilityShifted, false);
+          assert.equal(actual.authenticationStatus, threeDSResult.status);
+          assert.equal(actual.authenticationReason, threeDSResult.authentication_status_reason);
         });
       });
     });

--- a/test/component.js
+++ b/test/component.js
@@ -533,7 +533,7 @@ describe('hosted-fields-component', () => {
       const threeDSResult = {
         success:                      true,
         liability_shift:              'YES',
-        status:                       'YES', 
+        status:                       'YES',
         authentication_status_reason: 'UNAVAILABLE'
       };
 
@@ -585,7 +585,7 @@ describe('hosted-fields-component', () => {
       const threeDSResult = {
         success:                      true,
         liability_shift:              'NO',
-        status:                       'YES', 
+        status:                       'YES',
         authentication_status_reason: 'UNAVAILABLE'
       };
 

--- a/test/contingency-flow.js
+++ b/test/contingency-flow.js
@@ -76,12 +76,17 @@ describe('contingency-flow', () => {
     const onContingencyResult = td.explain(fakeContingencyInit).calls[0].args[0]
       .onContingencyResult;
 
-    onContingencyResult(null, {
-      success: true
-    });
+    const threeDSResult = {
+      success:                      true,
+      liability_shift:              'YES',
+      status:                       'YES',
+      authentication_status_reason: 'UNAVAILABLE'
+    };
+
+    onContingencyResult(null, threeDSResult);
 
     return promise.then((result) => {
-      assert(result.success);
+      assert.equal(result, threeDSResult);
     });
   });
 


### PR DESCRIPTION
To support additional data from helios after 3ds
In addition to the 'success' that is currently supported, there are 3 new values returned by helios:

- liability_shift
- status
- authentication_status_reason

sdk needs to map those values to 'liabilityShifted', 'authenticationStatus', 'authenticationReason', then returns to merchant.

This change has to be backward compatible so that it won't break the existing integration.