### PR TITLE
chore(docs): fixed urls in package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ flow-typed
 package-lock.json
 npm-debug.log
 
+# Text editor / IDE meta folder
+.vscode
+.idea
+

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/paypal/paypal-braintree-hosted-fields-component.git"
+    "url": "git+https://github.com/paypal/paypal-card-components.git"
   },
   "files": [
     "vendor/",
@@ -28,9 +28,9 @@
   "author": "dbrain",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/paypal/paypal-braintree-hosted-fields-component/issues"
+    "url": "https://github.com/paypal/paypal-card-components/issues"
   },
-  "homepage": "https://github.com/paypal/paypal-braintree-hosted-fields-component#readme",
+  "homepage": "https://github.com/paypal/paypal-card-components#readme",
   "devDependencies": {
     "flow-bin": "^0.100.0",
     "grumbler-scripts": "^3",


### PR DESCRIPTION
### What was changed?

Fixed `bugs`, `repository` and `homepage` details in `package.json`

### Why is this change necessary?
`npm bugs`, `npm repo`, `npm repo` will open correct links instead of `404`