### PR TITLE
Add support for installments

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -60,7 +60,7 @@ function createSubmitHandler (hostedFieldsInstance, orderIdFunction) : Function 
       logger.track({
         [ FPTI_KEY.STATE ]:              'CARD_PAYMENT_FORM',
         [ FPTI_KEY.TRANSITION ]:         'process_receive_order',
-        hosted_payment_has_installments:  String(options.hasOwnProperty('installments')),
+        payments_schedule:         options.hasOwnProperty('installments') ? 'INSTALLMENTS_PAYMENT'  : '',
         hosted_payment_session_id,
         [ FPTI_KEY.CONTEXT_TYPE ]:       'Cart-ID',
         [ FPTI_KEY.CONTEXT_ID ]:         orderId
@@ -180,23 +180,42 @@ export const HostedFields = {
       }
 
       onInstallmentsRequested = () => {
-        // eslint-disable-next-line no-warning-comments
-        // TODO logging here
+        logger.info('HOSTEDFIELDS_INSTALLMENTS_REQUESTED');
+        logger.track({
+          comp:                                'hostedpayment',
+          api_integration_type:                'PAYPALSDK',
+          [FPTI_KEY.STATE]:                    'CARD_PAYMENT_FORM',
+          [FPTI_KEY.TRANSITION]:               'process_installments_request'
+        });
+        logger.flush();
         // $FlowFixMe
         return options.installments.onInstallmentsRequested();
       };
       onInstallmentsAvailable = (...args) => {
-        // eslint-disable-next-line no-warning-comments
-        // TODO logging here
+        logger.info('HOSTEDFIELDS_INSTALLMENTS_AVAILABLE');
+        logger.track({
+          comp:                                'hostedpayment',
+          api_integration_type:                'PAYPALSDK',
+          [FPTI_KEY.STATE]:                    'CARD_PAYMENT_FORM',
+          [FPTI_KEY.TRANSITION]:               'process_card_issuer_installments'
+        });
+        logger.flush();
         // $FlowFixMe
         return options.installments.onInstallmentsAvailable(...args);
       };
 
       onInstallmentsError = (...args) => {
-        // eslint-disable-next-line no-warning-comments
-        // TODO logging here
         // $FlowFixMe
         if (typeof options.installments.onInstallmentsError === 'function') {
+          logger.warn('HOSTEDFIELDS_INSTALLMENTS_ERROR');
+          logger.track({
+            comp:                                'hostedpayment',
+            api_integration_type:                'PAYPALSDK',
+            [FPTI_KEY.STATE]:                    'CARD_PAYMENT_FORM',
+            [FPTI_KEY.TRANSITION]:               'process_installments_error'
+          });
+          logger.flush();
+
           // $FlowFixMe
           return options.installments.onInstallmentsError(...args);
         }
@@ -326,5 +345,5 @@ export function setupHostedFields() : Function {
   getUccEligibility.then((data) => {
     fundingEligibility = data;
   });
-  
+
 }

--- a/src/component.js
+++ b/src/component.js
@@ -132,7 +132,8 @@ export type OptionsType = {|
     onInstallmentsRequested : () => InstallmentsConfiguration | ZalgoPromise<InstallmentsConfiguration>,
     // eslint-disable-next-line no-warning-comments
     // TODO should probably be better defined than mixed here
-    onInstallmentsAvailable : (mixed) => void
+    onInstallmentsAvailable : (mixed) => void,
+    onInstallmentsError? : (mixed) => void
   |},
   onApprove : ({| |}) => void | ZalgoPromise<void>,
   onError? : (mixed) => void,

--- a/src/component.js
+++ b/src/component.js
@@ -120,8 +120,20 @@ function createSubmitHandler (hostedFieldsInstance, orderIdFunction) : Function 
   };
 }
 
-type OptionsType = {|
+export type InstallmentsConfiguration = {|
+  financingCountryCode : string,
+  currencyCode : string,
+  billingCountryCode : string,
+  amount : string
+|};
+export type OptionsType = {|
   createOrder : () => ZalgoPromise<string>,
+  installments? : {|
+    onInstallmentsRequested : () => InstallmentsConfiguration | ZalgoPromise<InstallmentsConfiguration>,
+    // eslint-disable-next-line no-warning-comments
+    // TODO should probably be better defined than mixed here
+    onInstallmentsAvailable : (mixed) => void
+  |},
   onApprove : ({| |}) => void | ZalgoPromise<void>,
   onError? : (mixed) => void,
   fields? : {|
@@ -152,6 +164,15 @@ export const HostedFields = {
 
     if (typeof options.createOrder !== 'function') {
       return ZalgoPromise.reject(new Error('createOrder parameter must be a function.'));
+    }
+
+    if (options.installments) {
+      if (
+        typeof options.installments.onInstallmentsRequested !== 'function' ||
+        typeof options.installments.onInstallmentsAvailable !== 'function'
+      ) {
+        return ZalgoPromise.reject(new Error('installments must include both onInstallmentsRequested and onInstallmentsAvailable functions'));
+      }
     }
 
     if (!getUccEligibility) {

--- a/src/component.js
+++ b/src/component.js
@@ -60,6 +60,7 @@ function createSubmitHandler (hostedFieldsInstance, orderIdFunction) : Function 
       logger.track({
         [ FPTI_KEY.STATE ]:              'CARD_PAYMENT_FORM',
         [ FPTI_KEY.TRANSITION ]:         'process_receive_order',
+        hosted_payment_has_installments:  String(options.hasOwnProperty('installments')),
         hosted_payment_session_id,
         [ FPTI_KEY.CONTEXT_TYPE ]:       'Cart-ID',
         [ FPTI_KEY.CONTEXT_ID ]:         orderId

--- a/src/component.js
+++ b/src/component.js
@@ -161,6 +161,9 @@ export const HostedFields = {
   },
 
   render(options : OptionsType, buttonSelector : string) : ZalgoPromise<HostedFieldsHandler> {
+    let onInstallmentsAvailable;
+    let onInstallmentsRequested;
+    let onInstallmentsError;
     const logger = getLogger();
 
     if (typeof options.createOrder !== 'function') {
@@ -174,6 +177,29 @@ export const HostedFields = {
       ) {
         return ZalgoPromise.reject(new Error('installments must include both onInstallmentsRequested and onInstallmentsAvailable functions'));
       }
+
+      onInstallmentsRequested = () => {
+        // eslint-disable-next-line no-warning-comments
+        // TODO logging here
+        // $FlowFixMe
+        return options.installments.onInstallmentsRequested();
+      };
+      onInstallmentsAvailable = (...args) => {
+        // eslint-disable-next-line no-warning-comments
+        // TODO logging here
+        // $FlowFixMe
+        return options.installments.onInstallmentsAvailable(...args);
+      };
+
+      onInstallmentsError = (...args) => {
+        // eslint-disable-next-line no-warning-comments
+        // TODO logging here
+        // $FlowFixMe
+        if (typeof options.installments.onInstallmentsError === 'function') {
+          // $FlowFixMe
+          return options.installments.onInstallmentsError(...args);
+        }
+      };
     }
 
     if (!getUccEligibility) {
@@ -221,6 +247,13 @@ export const HostedFields = {
       }
 
       const hostedFieldsCreateOptions = JSON.parse(JSON.stringify(options));
+      if (onInstallmentsRequested && onInstallmentsAvailable) {
+        hostedFieldsCreateOptions.installments = {
+          onInstallmentsRequested,
+          onInstallmentsAvailable,
+          onInstallmentsError
+        };
+      }
 
       return btClient.create({
         authorization: clientToken,

--- a/test/component.js
+++ b/test/component.js
@@ -12,6 +12,7 @@ import btClient from '../vendor/braintree-web/client';
 import hostedFields from '../vendor/braintree-web/hosted-fields';
 import { HostedFields, setupHostedFields } from '../src/index';
 import contingencyFlow from '../src/contingency-flow';
+import type { InstallmentsConfiguration } from '../src/component';
 
 import rejectIfResolves from './utils/reject-if-resolves';
 
@@ -114,6 +115,50 @@ describe('hosted-fields-component', () => {
 
       assert.equal(err, error);
     });
+  });
+
+  it('rejects if installments object is passed but no onInstallmentsRequested function is passed', () => {
+    const options = {
+      ...renderOptions,
+      installments: {
+        // eslint-disable-next-line no-unused-vars
+        onInstallmentsAvailable(installments) : void {
+          // render installments on page here
+        }
+      }
+    };
+
+    // $FlowFixMe
+    return HostedFields.render(options, '#button')
+      .then(rejectIfResolves)
+      .catch(err => {
+        // $FlowFixMe
+        assert.equal(err.message, 'installments must include both onInstallmentsRequested and onInstallmentsAvailable functions');
+      });
+  });
+
+  it('rejects if installments object is passed but no onInstallmentsAvailable function is passed', () => {
+    const options = {
+      ...renderOptions,
+      installments: {
+        onInstallmentsRequested() : InstallmentsConfiguration {
+          return {
+            financingCountryCode: 'ABC',
+            currencyCode:         'ABC',
+            billingCountryCode:   'ABC',
+            amount:               '100.00'
+          };
+        }
+      }
+    };
+
+    // $FlowFixMe
+    return HostedFields.render(options, '#button')
+      .then(rejectIfResolves)
+      .catch(err => {
+        // $FlowFixMe
+        assert.equal(err.message, 'installments must include both onInstallmentsRequested and onInstallmentsAvailable functions');
+      });
   });
 
   it('rejects with an error if braintree-web.hosted-fields errors out', () => {

--- a/vendor/braintree-web/hosted-fields/external/hosted-fields.js
+++ b/vendor/braintree-web/hosted-fields/external/hosted-fields.js
@@ -468,6 +468,11 @@ function HostedFields(options) {
   this._bus.on('INSTALLMENTS_AVAILABLE', function (data) {
     options.installments.onInstallmentsAvailable(data);
   });
+  this._bus.on('INSTALLMENTS_ERROR', function(installmentsLookupError) {
+    if (options.installments.onInstalmentsError) {
+      options.installments.onInstallmentsError(installmentsLookupError);
+    }
+  });
 
   this._bus.on(
     events.INPUT_EVENT,

--- a/vendor/braintree-web/hosted-fields/external/hosted-fields.js
+++ b/vendor/braintree-web/hosted-fields/external/hosted-fields.js
@@ -458,6 +458,17 @@ function HostedFields(options) {
     self._emit('ready');
   });
 
+  this._bus.on('INSTALLMENTS_REQUESTED', function (data, reply) {
+    Promise.resolve().then(function () {
+      return options.installments.onInstallmentsRequested();
+    }).then(function (data) {
+      reply(data);
+    });
+  });
+  this._bus.on('INSTALLMENTS_AVAILABLE', function (data) {
+    options.installments.onInstallmentsAvailable(data);
+  });
+
   this._bus.on(
     events.INPUT_EVENT,
     createInputEventHandler(fields).bind(this)
@@ -523,10 +534,15 @@ HostedFields.prototype._setupLabelFocus = function (type, container) {
 };
 
 HostedFields.prototype._waitForIframeInputsToBeReady = function (fieldCount, options) {
+  var installments = options.installments;
+
   return new Promise(function (resolve) {
     this._bus.on(events.FRAME_READY, function (reply) {
       fieldCount--;
       if (fieldCount === 0) {
+        if (installments) {
+          options.listenForInstallments = Boolean(installments.onInstallmentsRequested && installments.onInstallmentsAvailable);
+        }
         reply(options);
         resolve();
       }


### PR DESCRIPTION
Adds support for payment installments.

The code will basically look like:

```js
paypal.HostedFields({
  installments: {
    onInstallmentsRequested: () => {
      // this can alternatively return a promise
      // in the case that something async needs to happen
      // to get the details
      return {
        amount: '6000.00',
        currencyCode: 'MXN',
        financingCountryCode: 'MX',
        billingCountryCode: 'MX'
      }
    },
    onInstallmentsAvailable: (installments) => {
      // add installments to page
    }
  },
  fields: {
    number: {
      placeholder: '4111 1111 1111 1111',
      selector: '#number'
    },
    cvv: {
      placeholder: '123',
      selector: '#cvv'
    },
    expirationDate: {
      placeholder: 'MM / YY',
      selector: '#expirationDate'
    }
  }
}).render().then((hf) => {
  hf.submit({
    installments: {
      term, // get term from installments choice
      interval_duration, // get interval duration from choice
    }
  });
});
```

If either installments function is omitted, the installments will not be looked up.