### PR TITLE
adding loggers to the installment callbacks

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -60,7 +60,7 @@ function createSubmitHandler (hostedFieldsInstance, orderIdFunction) : Function 
       logger.track({
         [ FPTI_KEY.STATE ]:              'CARD_PAYMENT_FORM',
         [ FPTI_KEY.TRANSITION ]:         'process_receive_order',
-        payments_schedule: options.hasOwnProperty('installments') ? 'INSTALLMENTS_PAYMENT'  : '' ,
+        payments_schedule:         options.hasOwnProperty('installments') ? 'INSTALLMENTS_PAYMENT'  : '',
         hosted_payment_session_id,
         [ FPTI_KEY.CONTEXT_TYPE ]:       'Cart-ID',
         [ FPTI_KEY.CONTEXT_ID ]:         orderId
@@ -180,7 +180,6 @@ export const HostedFields = {
       }
 
       onInstallmentsRequested = () => {
-        // eslint-disable-next-line no-warning-comments
         logger.info('HOSTEDFIELDS_INSTALLMENTS_REQUESTED');
         logger.track({
           comp:                                'hostedpayment',
@@ -193,21 +192,19 @@ export const HostedFields = {
         return options.installments.onInstallmentsRequested();
       };
       onInstallmentsAvailable = (...args) => {
-        // eslint-disable-next-line no-warning-comments
-          logger.info('HOSTEDFIELDS_INSTALLMENTS_AVAILABLE');
-          logger.track({
-            comp:                                'hostedpayment',
-            api_integration_type:                'PAYPALSDK',
-            [FPTI_KEY.STATE]:                    'CARD_PAYMENT_FORM',
-            [FPTI_KEY.TRANSITION]:               'process_card_issuer_installments'
-          });
-          logger.flush();
+        logger.info('HOSTEDFIELDS_INSTALLMENTS_AVAILABLE');
+        logger.track({
+          comp:                                'hostedpayment',
+          api_integration_type:                'PAYPALSDK',
+          [FPTI_KEY.STATE]:                    'CARD_PAYMENT_FORM',
+          [FPTI_KEY.TRANSITION]:               'process_card_issuer_installments'
+        });
+        logger.flush();
         // $FlowFixMe
         return options.installments.onInstallmentsAvailable(...args);
       };
 
       onInstallmentsError = (...args) => {
-        // eslint-disable-next-line no-warning-comments
         // $FlowFixMe
         if (typeof options.installments.onInstallmentsError === 'function') {
           logger.warn('HOSTEDFIELDS_INSTALLMENTS_ERROR');
@@ -215,7 +212,7 @@ export const HostedFields = {
             comp:                                'hostedpayment',
             api_integration_type:                'PAYPALSDK',
             [FPTI_KEY.STATE]:                    'CARD_PAYMENT_FORM',
-            [FPTI_KEY.TRANSITION]:               'process_installments_error',
+            [FPTI_KEY.TRANSITION]:               'process_installments_error'
           });
           logger.flush();
 
@@ -348,5 +345,5 @@ export function setupHostedFields() : Function {
   getUccEligibility.then((data) => {
     fundingEligibility = data;
   });
-  
+
 }

--- a/src/component.js
+++ b/src/component.js
@@ -60,7 +60,7 @@ function createSubmitHandler (hostedFieldsInstance, orderIdFunction) : Function 
       logger.track({
         [ FPTI_KEY.STATE ]:              'CARD_PAYMENT_FORM',
         [ FPTI_KEY.TRANSITION ]:         'process_receive_order',
-        hosted_payment_has_installments:  String(options.hasOwnProperty('installments')),
+        payments_schedule: options.hasOwnProperty('installments') ? 'INSTALLMENTS_PAYMENT'  : '' ,
         hosted_payment_session_id,
         [ FPTI_KEY.CONTEXT_TYPE ]:       'Cart-ID',
         [ FPTI_KEY.CONTEXT_ID ]:         orderId
@@ -181,22 +181,44 @@ export const HostedFields = {
 
       onInstallmentsRequested = () => {
         // eslint-disable-next-line no-warning-comments
-        // TODO logging here
+        logger.info('HOSTEDFIELDS_INSTALLMENTS_REQUESTED');
+        logger.track({
+          comp:                                'hostedpayment',
+          api_integration_type:                'PAYPALSDK',
+          [FPTI_KEY.STATE]:                    'CARD_PAYMENT_FORM',
+          [FPTI_KEY.TRANSITION]:               'process_installments_request'
+        });
+        logger.flush();
         // $FlowFixMe
         return options.installments.onInstallmentsRequested();
       };
       onInstallmentsAvailable = (...args) => {
         // eslint-disable-next-line no-warning-comments
-        // TODO logging here
+          logger.info('HOSTEDFIELDS_INSTALLMENTS_AVAILABLE');
+          logger.track({
+            comp:                                'hostedpayment',
+            api_integration_type:                'PAYPALSDK',
+            [FPTI_KEY.STATE]:                    'CARD_PAYMENT_FORM',
+            [FPTI_KEY.TRANSITION]:               'process_card_issuer_installments'
+          });
+          logger.flush();
         // $FlowFixMe
         return options.installments.onInstallmentsAvailable(...args);
       };
 
       onInstallmentsError = (...args) => {
         // eslint-disable-next-line no-warning-comments
-        // TODO logging here
         // $FlowFixMe
         if (typeof options.installments.onInstallmentsError === 'function') {
+          logger.warn('HOSTEDFIELDS_INSTALLMENTS_ERROR');
+          logger.track({
+            comp:                                'hostedpayment',
+            api_integration_type:                'PAYPALSDK',
+            [FPTI_KEY.STATE]:                    'CARD_PAYMENT_FORM',
+            [FPTI_KEY.TRANSITION]:               'process_installments_error',
+          });
+          logger.flush();
+
           // $FlowFixMe
           return options.installments.onInstallmentsError(...args);
         }


### PR DESCRIPTION
This PR adds FPTI logging to the `onInstallmentsRequested()` and `onInstallmentsAvailable()` functions that were introduced in support for installments PR.

Depends on [Add support for installments #45](https://github.com/paypal/paypal-card-components/pull/45)

