### PR TITLE
Add destroy api to support sdk reloads for hosted-fields

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -4,6 +4,7 @@ import { getLogger, getClientToken, getCorrelationID, getPayPalAPIDomain, getVau
 import { FPTI_KEY } from '@paypal/sdk-constants/src';
 import { ZalgoPromise } from 'zalgo-promise/src';
 import { uniqueID } from 'belter/src';
+import { destroy as zoidDestroy } from 'zoid/src';
 
 // toodoo unvendor this when braintree-web is updated
 import btClient from '../vendor/braintree-web/client';
@@ -29,8 +30,8 @@ const LIABILITYSHIFTED_MAPPER = {
 
 const uccEligibilityFields = `
   card {
-      eligible 
-      branded 
+      eligible
+      branded
   }
 `;
 
@@ -270,5 +271,9 @@ export function setupHostedFields() : Function {
   getUccEligibility.then((data) => {
     fundingEligibility = data;
   });
-  
+
+}
+
+export function destroy() {
+  zoidDestroy();
 }


### PR DESCRIPTION
This PR adds a `destroy()` function for cleaning up the hosted-fields component when the JS SDK is reloaded. 

This is the same implementation as in paypal-checkout-components: https://github.com/paypal/paypal-checkout-components/blob/e1ef0e7c78a59192f3b395e1ed145f734af7ba7e/src/interface/button.js#L65

@bluepnume explained that `setup` and `destroy` are magic methods which get called by the sdk on setup and teardown.

