### PR TITLE
Update travis to use latest Node LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-   - "8"
+  - "lts/*"
 before_script:
   - npm run flow-typed
 script: npm run test


### PR DESCRIPTION
This PR updates travis to target all supported Node LTS versions.

Note that the Node 8 Maintenance LTS cycle expired on December 31, 2019.