### PR TITLE
Refactor contingencyFlow zoid component to support JS SDK Reloads

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -10,6 +10,7 @@ import { destroy as zoidDestroy } from 'zoid/src';
 import btClient from '../vendor/braintree-web/client';
 import hostedFields from '../vendor/braintree-web/hosted-fields';
 
+import { getContingencyFlowComponent } from './zoid/contingency-flow';
 import contingencyFlow from './contingency-flow';
 import type { HostedFieldsHandler } from './types';
 
@@ -78,7 +79,7 @@ function createSubmitHandler (hostedFieldsInstance, orderIdFunction) : Function 
         const url = `${ err.links.find(link => link.rel === '3ds-contingency-resolution').href  }`;
 
         logger.info('HOSTEDFIELDS_3DS');
-        return contingencyFlow.start(url);
+        return contingencyFlow.start(getContingencyFlowComponent(), url);
       }).then((payload) => {
         // does contingency flow give a payload?
         logger.track({
@@ -256,6 +257,9 @@ export function setupHostedFields() : Function {
   if (isChildWindow()) {
     return;
   }
+
+  // initialize the contingency flow zoid component
+  getContingencyFlowComponent();
 
   const merchantId = getMerchantID();
   const originalFundingEligibility = getFundingEligibility();

--- a/src/contingency-flow.js
+++ b/src/contingency-flow.js
@@ -1,231 +1,33 @@
 /* @flow */
 /* eslint import/no-default-export: off */
-
-import { getLogger, getClientID, getPayPalDomain, getSDKMeta } from '@paypal/sdk-client/src';
-import { create, CONTEXT, EVENT, type ZoidComponent } from 'zoid/src';
+import { getLogger } from '@paypal/sdk-client/src';
 import { ZalgoPromise } from 'zalgo-promise/src';
-import { parseQuery, destroyElement } from 'belter/src';
-import { node, dom } from 'jsx-pragmatic/src';
+import { parseQuery } from 'belter/src';
+import type { ZoidComponent } from 'zoid/src';
 
-const CONTINGENCY_TAG = 'payments-sdk-contingency-handler';
-
-const CLASS = {
-  OUTLET:          'outlet',
-  VISIBLE:         'visible',
-  INVISIBLE:       'invisible',
-  COMPONENT_FRAME: 'component-frame',
-  PRERENDER_FRAME: 'prerender-frame'
-};
-
-type ContingencyProps = {|
-  action : string,
-  cart_id : string,
-  flow : string,
-  xcomponent : string,
-  onContingencyResult : (err : mixed, result : Object) => void
-|};
+import type { ContingencyFlowProps } from './zoid/contingency-flow/props';
 
 let contingencyResolveFunction;
 
-const ContingencyComponent : ZoidComponent<ContingencyProps> = create({
-  url:      () => `${ getPayPalDomain() }/webapps/helios`,
-  props:    {
-    action: {
-      type:       'string',
-      queryParam: true
-    },
-    xcomponent: {
-      type:       'string',
-      queryParam: true
-    },
-    flow: {
-      type:       'string',
-      queryParam: true
-    },
-    cart_id: {
-      type:       'string',
-      queryParam: true
-    },
-    clientID: {
-      type:       'string',
-      value:      getClientID,
-      queryParam: 'client_id'
-    },
-    onContingencyResult: {
-      type: 'function'
-    },
-    onError: {
-      type: 'function'
-    },
-    sdkMeta: {
-      type:        'string',
-      queryParam:  true,
-      sendToChild: false,
-      value:       () => getSDKMeta()
-    }
-  },
-  tag: CONTINGENCY_TAG,
-  containerTemplate({ uid, tag, context, focus, close, frame, prerenderFrame, doc, event }) : ?HTMLElement {
-    if (!frame || !prerenderFrame) {
-      return;
-    }
-
-    function closeComponent(err) : ZalgoPromise<void> {
-      err.preventDefault();
-      err.stopPropagation();
-
-      if (contingencyResolveFunction) {
-        getLogger().info(`SKIPPED_BY_BUYER`);
-        contingencyResolveFunction({
-          success:                      false,
-          liability_shift:              'NO',
-          status:                       'NO',
-          authentication_status_reason: 'SKIPPED_BY_BUYER'
-        });
-        contingencyResolveFunction = null;
-      }
-      return close();
-    }
-
-    function focusComponent(err) : ZalgoPromise<void> {
-      err.preventDefault();
-      err.stopPropagation();
-      // $FlowFixMe
-      return focus();
-    }
-
-    frame.classList.add(CLASS.COMPONENT_FRAME);
-    prerenderFrame.classList.add(CLASS.PRERENDER_FRAME);
-
-    frame.classList.add(CLASS.INVISIBLE);
-    prerenderFrame.classList.add(CLASS.VISIBLE);
-
-    event.on(EVENT.RENDERED, () => {
-      prerenderFrame.classList.remove(CLASS.VISIBLE);
-      prerenderFrame.classList.add(CLASS.INVISIBLE);
-
-      frame.classList.remove(CLASS.INVISIBLE);
-      frame.classList.add(CLASS.VISIBLE);
-
-      setTimeout(() => {
-        destroyElement(prerenderFrame);
-      }, 1);
-    });
-    
-    /* eslint function-call-argument-newline: off */
-    return node('div', { 'id': uid, 'onClick': focusComponent, 'class': `${ tag } ${ tag }-tag-${ tag } ${ tag }-context-${ context } ${ tag }-focus` },
-
-      node('a', { 'href': '#', 'onClick': closeComponent, 'class': `${ tag }-close` }),
-
-      node('div', { class: CLASS.OUTLET },
-        node('node', { el: frame }),
-        node('node', { el: prerenderFrame })),
-
-      node('style', null, `
-          #${ uid } {
-              position: fixed;
-              top: 0;
-              left: 0;
-              width: 100%;
-              height: 100%;
-              background-color: rgba(0, 0, 0, 0.6);
-              z-index: 999;
-          }
-
-          #${ uid }.${ tag }-context-${ CONTEXT.POPUP } {
-              cursor: pointer;
-          }
-
-          #${ uid }.${ tag }-context-${ CONTEXT.IFRAME } .${ CLASS.OUTLET } {
-              box-shadow: 2px 2px 10px 3px rgba(0, 0, 0, 0.4);
-              position: fixed;
-              top: 50%;
-              left: 50%;
-              transform: translate3d(-50%, -50%, 0);
-              -webkit-transform: translate3d(-50%, -50%, 0);
-              -moz-transform: translate3d(-50%, -50%, 0);
-              -o-transform: translate3d(-50%, -50%, 0);
-              -ms-transform: translate3d(-50%, -50%, 0);
-          }
-
-          #${ uid }.${ tag }-context-${ CONTEXT.IFRAME } .${ CLASS.OUTLET } {
-              height: 510px;
-              width: 450px;
-          }
-
-          #${ uid }.${ tag }-context-${ CONTEXT.IFRAME } .${ CLASS.OUTLET } iframe {
-              height: 100%;
-              width: 100%;
-              position: absolute;
-              top: 0;
-              left: 0;
-              transition: opacity .2s ease-in-out;
-          }
-
-          #${ uid } > .${ CLASS.OUTLET } > iframe.${ CLASS.VISIBLE } {
-              opacity: 1;
-          }
-
-          #${ uid } > .${ CLASS.OUTLET } > iframe.${ CLASS.INVISIBLE } {
-              opacity: 0;
-          }
-
-          #${ uid } > .${ CLASS.OUTLET } > iframe.${ CLASS.COMPONENT_FRAME } {
-              z-index: 200;
-          }
-
-          #${ uid } > .${ CLASS.OUTLET } > iframe.${ CLASS.PRERENDER_FRAME } {
-              z-index: 100;
-          }
-
-          #${ uid } .${ tag }-close {
-              position: absolute;
-              right: 16px;
-              top: 16px;
-              width: 16px;
-              height: 16px;
-              opacity: 0.6;
-          }
-
-          #${ uid } .${ tag }-close:hover {
-              opacity: 1;
-          }
-
-          #${ uid } .${ tag }-close:before,
-          #${ uid } .${ tag }-close:after {
-              position: absolute;
-              left: 8px;
-              content: ' ';
-              height: 16px;
-              width: 2px;
-              background-color: white;
-          }
-
-          #${ uid } .${ tag }-close:before {
-              transform: rotate(45deg);
-          }
-
-          #${ uid } .${ tag }-close:after {
-              transform: rotate(-45deg);
-          }
-          `)).render(dom({ doc }));
+function skip() {
+  if (!contingencyResolveFunction) {
+    return;
   }
-});
 
-if (ContingencyComponent.isChild()) {
-  window.xchild = {
-    close: () => window.xprops.close()
-  };
+  getLogger().info(`SKIPPED_BY_BUYER`);
+  contingencyResolveFunction({
+    success:                      false,
+    liability_shift:              'NO',
+    status:                       'NO',
+    authentication_status_reason: 'SKIPPED_BY_BUYER'
+  });
+  contingencyResolveFunction = null;
 }
 
-const contingency = {
-  Component: ContingencyComponent
-};
-
-function start(url : string) : ZalgoPromise<Object> {
+function start(ContingencyFlowComponent : ZoidComponent<ContingencyFlowProps>, url : string) : ZalgoPromise<Object> {
   const params = parseQuery(url.split('?')[1]);
-  
   const body = document.body;
+
   if (!body) {
     throw new Error(`No document body available to render to`);
   }
@@ -234,7 +36,7 @@ function start(url : string) : ZalgoPromise<Object> {
     contingencyResolveFunction = resolve;
 
     // $FlowFixMe
-    contingency.Component({
+    ContingencyFlowComponent({
       action:              params.action,
       xcomponent:          '1',
       flow:                params.flow,
@@ -257,6 +59,6 @@ function start(url : string) : ZalgoPromise<Object> {
 }
 
 export default {
-  start,
-  contingency
+  skip,
+  start
 };

--- a/src/zoid/contingency-flow/component.js
+++ b/src/zoid/contingency-flow/component.js
@@ -1,0 +1,208 @@
+/* @flow */
+/* eslint import/no-default-export: off */
+
+import { getClientID, getPayPalDomain, getSDKMeta } from '@paypal/sdk-client/src';
+import { create, CONTEXT, EVENT, type ZoidComponent } from 'zoid/src';
+import { ZalgoPromise } from 'zalgo-promise/src';
+import { destroyElement, memoize } from 'belter/src';
+import { node, dom } from 'jsx-pragmatic/src';
+
+import contingencyFlow from '../../contingency-flow';
+
+import type { ContingencyFlowProps } from './props';
+
+const CONTINGENCY_TAG = 'payments-sdk-contingency-handler';
+
+const CLASS = {
+  OUTLET:          'outlet',
+  VISIBLE:         'visible',
+  INVISIBLE:       'invisible',
+  COMPONENT_FRAME: 'component-frame',
+  PRERENDER_FRAME: 'prerender-frame'
+};
+
+export const getContingencyFlowComponent = memoize(() : ZoidComponent<ContingencyFlowProps> => {
+  const ContingencyComponent : ZoidComponent<ContingencyFlowProps> = create({
+    url:      () => `${ getPayPalDomain() }/webapps/helios`,
+    props:    {
+      action: {
+        type:       'string',
+        queryParam: true
+      },
+      xcomponent: {
+        type:       'string',
+        queryParam: true
+      },
+      flow: {
+        type:       'string',
+        queryParam: true
+      },
+      cart_id: {
+        type:       'string',
+        queryParam: true
+      },
+      clientID: {
+        type:       'string',
+        value:      getClientID,
+        queryParam: 'client_id'
+      },
+      onContingencyResult: {
+        type: 'function'
+      },
+      onError: {
+        type: 'function'
+      },
+      sdkMeta: {
+        type:        'string',
+        queryParam:  true,
+        sendToChild: false,
+        value:       () => getSDKMeta()
+      }
+    },
+    tag: CONTINGENCY_TAG,
+    containerTemplate({ uid, tag, context, focus, close, frame, prerenderFrame, doc, event }) : ?HTMLElement {
+      if (!frame || !prerenderFrame) {
+        return;
+      }
+
+      function closeComponent(err) : ZalgoPromise<void> {
+        err.preventDefault();
+        err.stopPropagation();
+
+        contingencyFlow.skip();
+        return close();
+      }
+
+      function focusComponent(err) : ZalgoPromise<void> {
+        err.preventDefault();
+        err.stopPropagation();
+        // $FlowFixMe
+        return focus();
+      }
+
+      frame.classList.add(CLASS.COMPONENT_FRAME);
+      prerenderFrame.classList.add(CLASS.PRERENDER_FRAME);
+
+      frame.classList.add(CLASS.INVISIBLE);
+      prerenderFrame.classList.add(CLASS.VISIBLE);
+
+      event.on(EVENT.RENDERED, () => {
+        prerenderFrame.classList.remove(CLASS.VISIBLE);
+        prerenderFrame.classList.add(CLASS.INVISIBLE);
+
+        frame.classList.remove(CLASS.INVISIBLE);
+        frame.classList.add(CLASS.VISIBLE);
+
+        setTimeout(() => {
+          destroyElement(prerenderFrame);
+        }, 1);
+      });
+
+      /* eslint function-call-argument-newline: off */
+      return node('div', { 'id': uid, 'onClick': focusComponent, 'class': `${ tag } ${ tag }-tag-${ tag } ${ tag }-context-${ context } ${ tag }-focus` },
+
+        node('a', { 'href': '#', 'onClick': closeComponent, 'class': `${ tag }-close` }),
+
+        node('div', { class: CLASS.OUTLET },
+          node('node', { el: frame }),
+          node('node', { el: prerenderFrame })),
+
+        node('style', null, `
+            #${ uid } {
+                position: fixed;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
+                background-color: rgba(0, 0, 0, 0.6);
+                z-index: 999;
+            }
+
+            #${ uid }.${ tag }-context-${ CONTEXT.POPUP } {
+                cursor: pointer;
+            }
+
+            #${ uid }.${ tag }-context-${ CONTEXT.IFRAME } .${ CLASS.OUTLET } {
+                box-shadow: 2px 2px 10px 3px rgba(0, 0, 0, 0.4);
+                position: fixed;
+                top: 50%;
+                left: 50%;
+                transform: translate3d(-50%, -50%, 0);
+                -webkit-transform: translate3d(-50%, -50%, 0);
+                -moz-transform: translate3d(-50%, -50%, 0);
+                -o-transform: translate3d(-50%, -50%, 0);
+                -ms-transform: translate3d(-50%, -50%, 0);
+            }
+
+            #${ uid }.${ tag }-context-${ CONTEXT.IFRAME } .${ CLASS.OUTLET } {
+                height: 510px;
+                width: 450px;
+            }
+
+            #${ uid }.${ tag }-context-${ CONTEXT.IFRAME } .${ CLASS.OUTLET } iframe {
+                height: 100%;
+                width: 100%;
+                position: absolute;
+                top: 0;
+                left: 0;
+                transition: opacity .2s ease-in-out;
+            }
+
+            #${ uid } > .${ CLASS.OUTLET } > iframe.${ CLASS.VISIBLE } {
+                opacity: 1;
+            }
+
+            #${ uid } > .${ CLASS.OUTLET } > iframe.${ CLASS.INVISIBLE } {
+                opacity: 0;
+            }
+
+            #${ uid } > .${ CLASS.OUTLET } > iframe.${ CLASS.COMPONENT_FRAME } {
+                z-index: 200;
+            }
+
+            #${ uid } > .${ CLASS.OUTLET } > iframe.${ CLASS.PRERENDER_FRAME } {
+                z-index: 100;
+            }
+
+            #${ uid } .${ tag }-close {
+                position: absolute;
+                right: 16px;
+                top: 16px;
+                width: 16px;
+                height: 16px;
+                opacity: 0.6;
+            }
+
+            #${ uid } .${ tag }-close:hover {
+                opacity: 1;
+            }
+
+            #${ uid } .${ tag }-close:before,
+            #${ uid } .${ tag }-close:after {
+                position: absolute;
+                left: 8px;
+                content: ' ';
+                height: 16px;
+                width: 2px;
+                background-color: white;
+            }
+
+            #${ uid } .${ tag }-close:before {
+                transform: rotate(45deg);
+            }
+
+            #${ uid } .${ tag }-close:after {
+                transform: rotate(-45deg);
+            }
+            `)).render(dom({ doc }));
+    }
+  });
+
+  if (ContingencyComponent.isChild()) {
+    window.xchild = {
+      close: () => window.xprops.close()
+    };
+  }
+
+  return ContingencyComponent;
+});

--- a/src/zoid/contingency-flow/index.js
+++ b/src/zoid/contingency-flow/index.js
@@ -1,0 +1,3 @@
+/* @flow */
+
+export * from './component';

--- a/src/zoid/contingency-flow/props.js
+++ b/src/zoid/contingency-flow/props.js
@@ -1,0 +1,9 @@
+/* @flow */
+
+export type ContingencyFlowProps = {|
+    action : string,
+    cart_id : string,
+    flow : string,
+    xcomponent : string,
+    onContingencyResult : (err : mixed, result : Object) => void
+|};

--- a/test/component.js
+++ b/test/component.js
@@ -12,6 +12,7 @@ import btClient from '../vendor/braintree-web/client';
 import hostedFields from '../vendor/braintree-web/hosted-fields';
 import { HostedFields, setupHostedFields } from '../src/index';
 import contingencyFlow from '../src/contingency-flow';
+import { getContingencyFlowComponent } from '../src/zoid/contingency-flow';
 
 import rejectIfResolves from './utils/reject-if-resolves';
 
@@ -452,11 +453,12 @@ describe('hosted-fields-component', () => {
       td.when(fakeHostedFieldsInstance.tokenize(td.matchers.isA(Object)))
         .thenReject(error);
 
-      td.when(contingencyFlow.start(expectedUrl)).thenResolve(threeDSResult);
+      td.when(contingencyFlowStart(getContingencyFlowComponent(), expectedUrl)).thenResolve(threeDSResult);
 
       return HostedFields.render(renderOptions, '#button').then((handler) => {
         return handler.submit().then((actual) => {
-          td.verify(contingencyFlowStart(expectedUrl));
+
+          td.verify(contingencyFlowStart(getContingencyFlowComponent(), expectedUrl));
           assert.equal(actual.liabilityShifted, true);
         });
       });
@@ -495,11 +497,11 @@ describe('hosted-fields-component', () => {
       td.when(fakeHostedFieldsInstance.tokenize(td.matchers.isA(Object)))
         .thenReject(error);
 
-      td.when(contingencyFlow.start(expectedUrl)).thenReject();
+      td.when(contingencyFlowStart(getContingencyFlowComponent(), expectedUrl)).thenReject();
 
       return HostedFields.render(renderOptions, '#button').then((handler) => {
         return handler.submit().then(rejectIfResolves).catch(() => {
-          td.verify(contingencyFlowStart(expectedUrl));
+          td.verify(contingencyFlowStart(getContingencyFlowComponent(), expectedUrl));
         });
       });
     });
@@ -544,11 +546,11 @@ describe('hosted-fields-component', () => {
       td.when(fakeHostedFieldsInstance.tokenize(td.matchers.isA(Object)))
         .thenReject(error);
 
-      td.when(contingencyFlow.start(expectedUrl)).thenResolve(threeDSResult);
+      td.when(contingencyFlowStart(getContingencyFlowComponent(), expectedUrl)).thenResolve(threeDSResult);
 
       return HostedFields.render(renderOptions, '#button').then((handler) => {
         return handler.submit().then((actual) => {
-          td.verify(contingencyFlowStart(expectedUrl));
+          td.verify(contingencyFlowStart(getContingencyFlowComponent(), expectedUrl));
           assert.equal(actual.liabilityShifted, true);
           assert.equal(actual.authenticationStatus, threeDSResult.status);
           assert.equal(actual.authenticationReason, threeDSResult.authentication_status_reason);
@@ -596,11 +598,11 @@ describe('hosted-fields-component', () => {
       td.when(fakeHostedFieldsInstance.tokenize(td.matchers.isA(Object)))
         .thenReject(error);
 
-      td.when(contingencyFlow.start(expectedUrl)).thenResolve(threeDSResult);
+      td.when(contingencyFlowStart(getContingencyFlowComponent(), expectedUrl)).thenResolve(threeDSResult);
 
       return HostedFields.render(renderOptions, '#button').then((handler) => {
         return handler.submit().then((actual) => {
-          td.verify(contingencyFlowStart(expectedUrl));
+          td.verify(contingencyFlowStart(getContingencyFlowComponent(), expectedUrl));
           assert.equal(actual.liabilityShifted, false);
           assert.equal(actual.authenticationStatus, threeDSResult.status);
           assert.equal(actual.authenticationReason, threeDSResult.authentication_status_reason);

--- a/test/contingency-flow.js
+++ b/test/contingency-flow.js
@@ -10,14 +10,15 @@ import contingencyFlow from '../src/contingency-flow';
 import rejectIfResolves from './utils/reject-if-resolves';
 
 describe('contingency-flow', () => {
-  let fakeContingencyInit;
-  let fakeContingencyComponentRender;
+  let fakeContingencyFlowComponent;
+  let fakeContingencyFlowComponentRender;
 
   beforeEach(() => {
-    fakeContingencyInit = td.replace(contingencyFlow.contingency, 'Component');
-    fakeContingencyComponentRender = td.func();
-    td.when(fakeContingencyInit(), { ignoreExtraArgs: true }).thenReturn({
-      render: fakeContingencyComponentRender
+    fakeContingencyFlowComponentRender = td.func();
+    fakeContingencyFlowComponent = td.func();
+
+    td.when(fakeContingencyFlowComponent(), { ignoreExtraArgs: true }).thenReturn({
+      render: fakeContingencyFlowComponentRender
     });
   });
 
@@ -26,9 +27,9 @@ describe('contingency-flow', () => {
   });
 
   it('renders a zoid component', () => {
-    contingencyFlow.start('https://example.com?cart_id=abc123&action=action&xcomponent=1&flow=contingency');
+    contingencyFlow.start(fakeContingencyFlowComponent, 'https://example.com?cart_id=abc123&action=action&xcomponent=1&flow=contingency');
 
-    td.verify(fakeContingencyInit({
+    td.verify(fakeContingencyFlowComponent({
       action:              'action',
       xcomponent:           '1',
       flow:                'contingency',
@@ -37,12 +38,12 @@ describe('contingency-flow', () => {
       onError:             td.matchers.isA(Function)
     }));
 
-    td.verify(fakeContingencyComponentRender(document.body));
+    td.verify(fakeContingencyFlowComponentRender(document.body));
   });
 
   it('rejects when contingency returns an error object with code and description', () => {
-    const promise = contingencyFlow.start('https://example.com?cart_id=abc123&action=contingency&xcomponent=1&flow=contingency');
-    const onContingencyResult = td.explain(fakeContingencyInit).calls[0].args[0]
+    const promise = contingencyFlow.start(fakeContingencyFlowComponent, 'https://example.com?cart_id=abc123&action=contingency&xcomponent=1&flow=contingency');
+    const onContingencyResult = td.explain(fakeContingencyFlowComponent).calls[0].args[0]
       .onContingencyResult;
     const error = {
       code:        42,
@@ -57,8 +58,8 @@ describe('contingency-flow', () => {
   });
 
   it('rejects when contingency returns an error object with description only', () => {
-    const promise = contingencyFlow.start('https://example.com?cart_id=abc123&action=contingency&xcomponent=1&flow=contingency');
-    const onContingencyResult = td.explain(fakeContingencyInit).calls[0].args[0]
+    const promise = contingencyFlow.start(fakeContingencyFlowComponent, 'https://example.com?cart_id=abc123&action=contingency&xcomponent=1&flow=contingency');
+    const onContingencyResult = td.explain(fakeContingencyFlowComponent).calls[0].args[0]
       .onContingencyResult;
     const error = {
       description: 'The error of life'
@@ -72,8 +73,8 @@ describe('contingency-flow', () => {
   });
 
   it('resolves when contingency is successful', () => {
-    const promise = contingencyFlow.start('https://example.com?cart_id=abc123&action=contingency&xcomponent=1&flow=contingency');
-    const onContingencyResult = td.explain(fakeContingencyInit).calls[0].args[0]
+    const promise = contingencyFlow.start(fakeContingencyFlowComponent, 'https://example.com?cart_id=abc123&action=contingency&xcomponent=1&flow=contingency');
+    const onContingencyResult = td.explain(fakeContingencyFlowComponent).calls[0].args[0]
       .onContingencyResult;
 
     const threeDSResult = {
@@ -92,8 +93,8 @@ describe('contingency-flow', () => {
 
   it('rejects when onError is called with an error', () => {
     const randomError = new Error('spooky');
-    const promise = contingencyFlow.start('https://example.com?cart_id=abc123&action=contingency&xcomponent=1&flow=contingency');
-    const onError = td.explain(fakeContingencyInit).calls[0].args[0]
+    const promise = contingencyFlow.start(fakeContingencyFlowComponent, 'https://example.com?cart_id=abc123&action=contingency&xcomponent=1&flow=contingency');
+    const onError = td.explain(fakeContingencyFlowComponent).calls[0].args[0]
       .onError;
 
     onError(randomError);


### PR DESCRIPTION
This PR fixes the "listener already exists" error when reloading the JS SDK when using hosted-fields (originally reported here: https://github.com/paypal/paypal-sdk-client/issues/44).

<img width="1234" alt="Screen Shot 2020-09-11 at 9 44 28 PM" src="https://user-images.githubusercontent.com/534034/92985462-42ab5900-f478-11ea-98cb-676509def250.png">

The error is fixed by creating the zoid component in the setupHandler instead so it can be cleaned up in the `destroy()` hook to play nice with the [setup/destroy workflow of the sdk-client](https://github.com/paypal/paypal-sdk-client/blob/master/src/setup.js#L14).

### Additional Info

This PR refactors the zoid component to use the same [memoize getter approach that the Buttons component uses](https://github.com/paypal/paypal-checkout-components/blob/master/src/zoid/buttons/component.jsx#L24). This makes it easy to reference the component in multiple places while only creating it once. 

This PR breaks up the contingency flow component into two files. I made this change to make it easier to unit test and to follow the zoid folder pattern used in other repos. I learned that the testdouble.js library considers [partial mocks an anti-pattern](https://github.com/testdouble/contributing-tests/wiki/Partial-Mock) so having two files avoids the need to partially mock the subject.