### PR TITLE
set session id as client meta id for fraudnet

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "release:major": "./publish.sh major",
     "flow-typed": "rm -rf ./flow-typed && flow-typed install",
     "flow": "flow",
-    "build": "rm -rf ./vendor && mkdir -p ./vendor/braintree-web && cp -R ~/bt/braintree.js/dist/npm/* ./vendor/braintree-web",
     "lint": "eslint src/ test/ *.js",
     "test": "npm run lint && npm run flow-typed && npm run flow && npm run karma",
     "karma": "cross-env NODE_ENV=test babel-node --plugins=transform-es2015-modules-commonjs ./node_modules/.bin/karma start"

--- a/vendor/braintree-web/data-collector/fraudnet.js
+++ b/vendor/braintree-web/data-collector/fraudnet.js
@@ -6,7 +6,7 @@ function setup() {
 }
 
 function Fraudnet() {
-  this.sessionId = _generateSessionId();
+  this.sessionId = sdkClient.getClientMetadataID() || _generateSessionId();
   this._beaconId = _generateBeaconId(this.sessionId);
 
   this._parameterBlock = _createParameterBlock(this.sessionId, this._beaconId);


### PR DESCRIPTION
Jira Ticket: https://engineering.paypalcorp.com/jira/browse/DTPPSDK-570

package.json - script - build: This script was unused and at this point would cause problems if it did what it says it should. Also, its unclear where `~/bt/braintree.js/dist/npm/*` is

`this.sessionId` changes: We are doing what was outlined in the Jira ticket

We are working on how to actually test this, TBD