### PR TITLE
fix hosted fields loading in lite modes

### DIFF
--- a/vendor/braintree-web/hosted-fields/external/hosted-fields.js
+++ b/vendor/braintree-web/hosted-fields/external/hosted-fields.js
@@ -416,7 +416,8 @@ function HostedFields(options) {
     frame = iFramer({
       type: key,
       name: 'braintree-hosted-field-' + key,
-      style: constants.defaultIFrameStyle
+      style: constants.defaultIFrameStyle,
+      loading: "eager"
     });
 
     this._injectedNodes = this._injectedNodes.concat(injectFrame(frame, container));


### PR DESCRIPTION
## Description

Under Android Chrome’s Lite mode, the credit card input field on UCC is not properly shown on merchant sites. Please see below screen captures. IT seems to be [chrome's lite mode](https://blog.chromium.org/2019/04/data-saver-is-now-lite-mode.html)

![image](https://user-images.githubusercontent.com/17114924/155993228-6124afb6-6fc8-49b0-89df-ac17e56c9099.png)

To reduce network data and increase site speed by prioritizing content visible to the user, in Chrome Lite mode the loading attributes of iframes **are set to 'lazy'** with which Chrome will defer a load of below-the-fold images and iframes until the user scrolls near them (distance criteria) and effective network type.[1]

## Solution Description:

A suggested fix by GPS team in Japan is to set the iframes to eager loading explicitly so that hosted fields in Chrome light mode will not be converted into lazy to avoid the bug we have explained. 

[Jira Ticket](https://engineering.paypalcorp.com/jira/browse/DTCHKINT-1081)


## References
[1] [Automatically lazy-loading offscreen images & iframes for Lite mode users](https://blog.chromium.org/2019/10/automatically-lazy-loading-offscreen.html)


