### PR TITLE
remove travis-ci.org build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Hosted Fields Component
 -----------------------
 
-[![npm version](https://img.shields.io/npm/v/@paypal/card-components.svg?style=flat-square)](https://www.npmjs.com/package/@paypal/card-components) [![build status](https://img.shields.io/travis/paypal/paypal-card-components/master.svg?style=flat-square)](https://travis-ci.org/paypal/paypal-card-components)
+[![npm version](https://img.shields.io/npm/v/@paypal/card-components.svg?style=flat-square)](https://www.npmjs.com/package/@paypal/card-components)
 
 [![dependencies Status](https://david-dm.org/paypal/paypal-card-components/status.svg)](https://david-dm.org/paypal/paypal-card-components) [![devDependencies Status](https://david-dm.org/paypal/paypal-card-components/dev-status.svg)](https://david-dm.org/paypal/paypal-card-components?type=dev)
 


### PR DESCRIPTION
Don't mind me, just doing some spring cleaning. travis-ci.org stopped running builds nearly a year ago, and this repo has been moved to GitHub actions for some time.