### PR TITLE
chore: add orderID alias

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -10,7 +10,7 @@ const fundingEligibility = {
   card: {
     eligible: true,
     branded:  false,
-    
+
     vendors: {
       visa: {
         eligible: true
@@ -56,16 +56,17 @@ export default (karma : Object) : void =>
         __COMMIT__: true,
         __VAULT__:  true,
 
-        __PORT__:              8000,
-        __PAYPAL_API_DOMAIN__: 'msmaster.qa.paypal.com',
-        __STAGE_HOST__:        'msmaster.qa.paypal.com',
-        __HOST__:              'test.paypal.com',
-        __HOSTNAME__:          'test.paypal.com',
-        __SDK_HOST__:          'test.paypal.com',
-        __PATH__:              '/sdk/js',
-        __CORRELATION_ID__:    'abc123',
-        __VERSION__:           '1.0.55',
-        __NAMESPACE__:         'testpaypal',
+        __PORT__:               8000,
+        __PAYPAL_API_DOMAIN__:  'msmaster.qa.paypal.com',
+        __STAGE_HOST__:         'msmaster.qa.paypal.com',
+        __HOST__:               'test.paypal.com',
+        __HOSTNAME__:           'test.paypal.com',
+        __SDK_HOST__:           'test.paypal.com',
+        __PATH__:               '/sdk/js',
+        __CORRELATION_ID__:     'abc123',
+        __VERSION__:            '1.0.55',
+        __NAMESPACE__:          'testpaypal',
+        __DISABLE_SET_COOKIE__: false,
 
         __FUNDING_ELIGIBILITY__: fundingEligibility
       }

--- a/src/component.js
+++ b/src/component.js
@@ -107,7 +107,9 @@ function createSubmitHandler (hostedFieldsInstance, orderIdFunction) : Function 
           authenticationStatus: payload.status,
           authenticationReason: payload.authentication_status_reason,
           card:                 payload && payload.payment_source && payload.payment_source.card,
-          orderId
+          orderId,
+          // add "orderID" alias to be consistent with the Buttons component interface with `onApprove({ orderID })`
+          orderID: orderId
         };
       }).catch((err) => {
         paymentInProgress = false;


### PR DESCRIPTION
This PR adds the "orderID" alias to the submit() promise payload to be consistent with the Buttons component.

### Problem

The problem we currently have is the `paypal.Buttons` and `paypal.HostedFields` components are not consistent with the casing for orderID.

- Buttons using `onApprove({ orderID })` - https://github.com/paypal-examples/paypal-sdk-server-side-integration/blob/main/public/buttons.html#L103
- HostedFields using `submit().then({ orderId })` - https://github.com/paypal-examples/paypal-sdk-server-side-integration/blob/main/public/hosted-fields.html#L180

### Solution

We don't want to make any breaking changes with this interface. Instead, the proposal is to update the HostedFields component to support both `orderId` and `orderID` and then update all of our public docs to recommend `orderID` just like we do with the Buttons component.

Ex:
```js
hostedFieldsInstance
.submit()
.then((hostedFieldsOrderData) => {
  const orderID = hostedFieldsOrderData.orderID;

  return onApprove(orderID);
})
```