### PR TITLE
chore: remove unused bt-web dep

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,6 @@
 [ignore]
 .*/node_modules/babel-plugin-flow-runtime
+.*/node_modules/es-abstract
 .*/node_modules/npm
 .*/node_modules/jsonlint
 .*/node_modules/resolve

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@krakenjs/zalgo-promise": "^2.0.0",
     "@krakenjs/zoid": "^10.0.0",
     "@paypal/sdk-client": "^4.0.166",
-    "@paypal/sdk-constants": "^1.0.8",
-    "braintree-web": "3.33.0"
+    "@paypal/sdk-constants": "^1.0.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,11 +40,22 @@
     "testdouble": "^3.7.0"
   },
   "dependencies": {
+    "@braintree/browser-detection": "1.7.0",
+    "@braintree/iframer": "1.0.3",
+    "@braintree/sanitize-url": "2.1.0",
+    "@braintree/wrap-promise": "1.1.1",
     "@krakenjs/belter": "^2.0.0",
     "@krakenjs/jsx-pragmatic": "^3.0.0",
     "@krakenjs/zalgo-promise": "^2.0.0",
     "@krakenjs/zoid": "^10.0.0",
     "@paypal/sdk-client": "^4.0.166",
-    "@paypal/sdk-constants": "^1.0.8"
+    "@paypal/sdk-constants": "^1.0.8",
+    "card-validator": "4.3.0",
+    "credit-card-type": "6.3.0",
+    "framebus": "3.0.1",
+    "inject-stylesheet": "1.0.0",
+    "promise-polyfill": "7.0.2",
+    "restricted-input": "1.2.7"
+
   }
 }


### PR DESCRIPTION
This dependency is not used and any of the Braintree SDK that's used is done via the vendored in code. Removing this because it also caused issues with a promise polyfill version clash previously when working with the Connect component. 

I locally set up the SDK to pull local Card Components and verified the removal of this dep didn't break things, hunted for any places it might otherwise be used in this repo, and validated that the vendored in code does the version match check that enforces BT SDK integrations all being of the same version.
The vendored code uses version `3.32.0-payments-sdk-dev`, and the package.json dependnecy this PR removes is version `3.33.0`. Those make for an incompatibility between the vendored in code and the NPM dependnecy.