### PR TITLE
fix: remove heroku and paypalcorp domains

### DIFF
--- a/vendor/braintree-web/lib/is-whitelisted-domain.js
+++ b/vendor/braintree-web/lib/is-whitelisted-domain.js
@@ -3,12 +3,9 @@
 var parser;
 var legalHosts = {
   'paypal.com': 1,
-  'paypalcorp.com': 1,
   'braintreepayments.com': 1,
   'braintreegateway.com': 1,
-  'braintree-api.com': 1,
-  // TODO remove this hack!
-  'herokuapp.com': 1
+  'braintree-api.com': 1
 };
 
 function stripSubdomains(domain) {


### PR DESCRIPTION
This PR removes herokuapp.com and paypalcorp.com from legalHosts for [LI-160880](https://paypal.atlassian.net/browse/LI-160880).

Before
<img width="1509" height="909" alt="Screenshot 2026-06-15 at 12 50 00 PM" src="https://github.com/user-attachments/assets/d59a95db-9303-45a8-b98c-c71907d3a52a" />

After
<img width="1512" height="911" alt="Screenshot 2026-06-15 at 12 48 47 PM" src="https://github.com/user-attachments/assets/db4ef799-0502-43d2-8c06-b07af65b1923" />
